### PR TITLE
Multi-arch support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # Use a multi-platform base image
-FROM --platform=$BUILDPLATFORM rust:1.87-alpine AS builder
+FROM --platform=$TARGETPLATFORM rust:1.88-alpine AS builder
 
 # Set build arguments to support cross-compilation
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
+ARG TARGETARCH
 
 WORKDIR /usr/src/app
 COPY . .
@@ -11,15 +12,16 @@ COPY . .
 # Install build dependencies for Rust on Alpine
 RUN apk add --no-cache build-base openssl-dev pkgconf
 
-# Install cross-compilation tools if needed
-RUN if [ "$BUILDPLATFORM" != "$TARGETPLATFORM" ]; then \
-    rustup target add aarch64-unknown-linux-musl x86_64-unknown-linux-musl; \
-    fi
+# Add the appropriate Rust target for the platform
+RUN case "$TARGETARCH" in \
+    "amd64") rustup target add x86_64-unknown-linux-musl ;; \
+    "arm64") rustup target add aarch64-unknown-linux-musl ;; \
+    esac
 
 # Build with release optimizations (using the appropriate musl target)
-RUN case "$TARGETPLATFORM" in \
-    "linux/amd64") cargo build --release --target x86_64-unknown-linux-musl ;; \
-    "linux/arm64") cargo build --release --target aarch64-unknown-linux-musl ;; \
+RUN case "$TARGETARCH" in \
+    "amd64") cargo build --release --target x86_64-unknown-linux-musl ;; \
+    "arm64") cargo build --release --target aarch64-unknown-linux-musl ;; \
     *) cargo build --release ;; \
     esac
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN case "$TARGETPLATFORM" in \
 FROM --platform=$TARGETPLATFORM alpine:3.19
 
 # Install runtime dependencies (minimal)
-RUN apk add --no-cache ca-certificates openssl libc6-compat
+RUN apk add --no-cache ca-certificates openssl libc6-compat netcat-openbsd
 
 WORKDIR /app
 


### PR DESCRIPTION
Closing https://github.com/celestiaorg/localestia/pull/5 in favor of this PR.

This pull request updates the `Dockerfile` to improve multi-platform Rust builds and streamline the cross-compilation process. The changes focus on upgrading the Rust base image, refining how Rust targets are selected and built for different architectures, and adding a useful runtime dependency for networking.

**Build process improvements:**

* Upgraded the Rust base image from `1.87-alpine` to `1.88-alpine` to use the latest stable Rust version.
* Changed the logic for selecting Rust targets and building for different architectures to use the `TARGETARCH` build argument, making the process more robust and explicit for `amd64` and `arm64` platforms.

**Runtime enhancements:**

* Added `netcat-openbsd` to the runtime image dependencies, providing networking utilities that can be useful for debugging or health checks.